### PR TITLE
Planck v0.2.0

### DIFF
--- a/plugins/planck_matter_hooks/src/init.lua
+++ b/plugins/planck_matter_hooks/src/init.lua
@@ -112,7 +112,7 @@ function Plugin:build(scheduler: any)
 
 	local phaseDetails = {}
 
-	for _, phase in scheduler._orderedPhases do
+	for phase, _ in scheduler._phaseToSystems do
 		if not phaseDetails[phase] then
 			phaseDetails[phase] = {
 				lastTime = os.clock(),

--- a/src/DependencyGraph.luau
+++ b/src/DependencyGraph.luau
@@ -1,0 +1,180 @@
+local AdjacencyMatrix = {}
+AdjacencyMatrix.__index = AdjacencyMatrix
+
+function AdjacencyMatrix:__tostring()
+	local s = "\n"
+
+	for i = 1, self.length do
+		if i == 1 then
+			s ..= "\n"
+		end
+
+		local sub = ""
+		for j = 1, self.width do
+			if j == self.width then
+				sub ..= `{self.matrix[i][j]}`
+				continue
+			end
+
+			sub ..= `{self.matrix[i][j]}, `
+		end
+
+		sub ..= "\n"
+		s ..= sub
+	end
+
+	return s
+end
+
+function AdjacencyMatrix:extend()
+	self.length = (self.length :: number) + 1
+	self.width = (self.length :: number) + 1
+
+	self.matrix[self.length] = {}
+	for j = 1, self.width do
+		self.matrix[self.length][j] = 0
+	end
+
+	for i = 1, self.length do
+		self.matrix[i][self.width] = 0
+	end
+end
+
+function AdjacencyMatrix:setEdge(i, j, val)
+	self.matrix[i][j] = val
+end
+
+function AdjacencyMatrix:toAdjacencyList()
+	local list = {}
+
+	for i = 1, self.length do
+		list[i] = {}
+		for j = 1, self.width do
+			if self.matrix[i][j] ~= 0 then
+				table.insert(list[i], j)
+			end
+		end
+	end
+
+	return list
+end
+
+function AdjacencyMatrix:topologicalSort(): { number }?
+	local adjacencyList = self:toAdjacencyList()
+
+	local result = {}
+	local inDegrees = table.create(self.length, 0)
+
+	for i = 1, self.length do
+		for _, j in adjacencyList[i] do
+			inDegrees[j] += 1
+		end
+	end
+
+	local queue = {}
+	for i = 1, self.length do
+		if inDegrees[i] == 0 then
+			table.insert(queue, i)
+		end
+	end
+
+	while #queue ~= 0 do
+		local i = table.remove(queue, 1) :: number
+		table.insert(result, i)
+
+		for _, j in adjacencyList[i] do
+			inDegrees[j] -= 1
+			if inDegrees[j] == 0 then
+				table.insert(queue, j)
+			end
+		end
+	end
+
+	if #result ~= self.length then
+		return nil
+	end
+
+	return result
+end
+
+function AdjacencyMatrix.new()
+	return setmetatable({
+		matrix = {},
+		length = 0,
+		width = 0,
+	}, AdjacencyMatrix)
+end
+
+local DependencyGraph = {}
+DependencyGraph.__index = DependencyGraph
+
+function DependencyGraph:getOrderedList(): { any }?
+	local orderedList = {}
+
+	local topologicalSort = self.matrix:topologicalSort()
+	if not topologicalSort then
+		return nil
+	end
+
+	for _, i in topologicalSort do
+		table.insert(orderedList, self.nodes[i])
+	end
+
+	return orderedList
+end
+
+function DependencyGraph:insertBefore(node, beforeNode)
+	if not table.find(self.nodes, beforeNode) then
+		error("Node not found in DependencyGraph:insertBefore(_, unknown)")
+	end
+
+	table.insert(self.nodes, node)
+	local j = #self.nodes
+	local i = table.find(self.nodes, beforeNode)
+
+	self.matrix:extend()
+	self.matrix:setEdge(j, i, 1)
+
+	return self
+end
+
+function DependencyGraph:insertAfter(node, afterNode)
+	if not table.find(self.nodes, afterNode) then
+		error("Node not found in DependencyGraph:insertAfter(_, unknown)")
+	end
+
+	table.insert(self.nodes, node)
+
+	local j = #self.nodes
+	local i = table.find(self.nodes, afterNode)
+
+	self.matrix:extend()
+	self.matrix:setEdge(i, j, 1)
+
+	return self
+end
+
+function DependencyGraph:insert(node)
+	local i = #self.nodes
+	table.insert(self.nodes, node)
+	local j = #self.nodes
+
+	self.matrix:extend()
+
+	if i ~= 0 then
+		self.matrix:setEdge(i, j, 1)
+	end
+
+	return self
+end
+
+function DependencyGraph.new()
+	return setmetatable({
+		nodes = {},
+		matrix = AdjacencyMatrix.new(),
+		length = 0,
+		width = 0,
+	}, DependencyGraph)
+end
+
+return DependencyGraph

--- a/src/Pipeline.luau
+++ b/src/Pipeline.luau
@@ -1,3 +1,5 @@
+--!nonstrict
+local DependencyGraph = require("@Project/DependencyGraph")
 local Phase = require("@Project/Phase")
 
 --- @class Pipeline
@@ -19,22 +21,37 @@ end
 ---
 --- Adds a Phase to the Pipeline, ordering it implicitly.
 function Pipeline:insert(phase)
-	table.insert(self._phases, phase)
+	self.dependencyGraph:insert(phase)
 	return self
 end
 
---- @method insert
+--- @method insertAfter
 --- @within Pipeline
 --- @param phase Phase
 --- @param after Phase
 --- @return Pipeline
 ---
 --- Adds a Phase to the Pipeline after another Phase, ordering it explicitly.
-function Pipeline:insertAfter(phase, otherPhase)
-	local i = table.find(self._phases, phase)
-	assert(i, "Phase not initialized in Pipeline")
+function Pipeline:insertAfter(phase, afterPhase)
+	local i = table.find(self.dependencyGraph.nodes, afterPhase)
+	assert(i, "Unknown Phase in Pipeline:insertAfter(_, unknown), try adding this Phase to the Pipeline.")
 
-	table.insert(self._phases, i + 1, otherPhase)
+	self.dependencyGraph:insertAfter(phase, afterPhase)
+	return self
+end
+
+--- @method insertBefore
+--- @within Pipeline
+--- @param phase Phase
+--- @param before Phase
+--- @return Pipeline
+---
+--- Adds a Phase to the Pipeline before another Phase, ordering it explicitly.
+function Pipeline:insertBefore(phase, beforePhase)
+	local i = table.find(self.dependencyGraph.nodes, beforePhase)
+	assert(i, "Unknown Phase in Pipeline:insertBefore(_, unknown), try adding this Phase to the Pipeline.")
+
+	self.dependencyGraph:insertBefore(phase, beforePhase)
 	return self
 end
 
@@ -47,7 +64,7 @@ function Pipeline.new(name: string?)
 	return setmetatable({
 		_name = name,
 		_type = "pipeline",
-		_phases = {},
+		dependencyGraph = DependencyGraph.new(),
 	}, Pipeline)
 end
 

--- a/src/Scheduler.luau
+++ b/src/Scheduler.luau
@@ -105,8 +105,7 @@ function Scheduler:_handleLogs(systemInfo)
 end
 
 function Scheduler:runSystem(system)
-	local runIf = self._runIfConditions[system]
-	if runIf and runIf(table.unpack(self._vargs)) == false then
+	if self:_canRun(system) == false then
 		return
 	end
 
@@ -205,8 +204,7 @@ function Scheduler:runSystem(system)
 end
 
 function Scheduler:runPhase(phase)
-	local runIf = self._runIfConditions[phase]
-	if runIf and runIf(table.unpack(self._vargs)) == false then
+	if self:_canRun(phase) == false then
 		return
 	end
 
@@ -222,8 +220,7 @@ function Scheduler:runPhase(phase)
 end
 
 function Scheduler:runPipeline(pipeline)
-	local runIf = self._runIfConditions[pipeline]
-	if runIf and runIf(table.unpack(self._vargs)) == false then
+	if self:_canRun(pipeline) == false then
 		return
 	end
 
@@ -236,6 +233,20 @@ function Scheduler:runPipeline(pipeline)
 	for _, phase in orderedList do
 		self:runPhase(phase)
 	end
+end
+
+function Scheduler:_canRun(dependent)
+	local conditions = self._runIfConditions[dependent]
+
+	if conditions then
+		for _, runIf in conditions do
+			if runIf(table.unpack(self._vargs)) == false then
+				return false
+			end
+		end
+	end
+
+	return true
 end
 
 --- @method run
@@ -523,8 +534,10 @@ function Scheduler:addSystem(system, phase)
 
 	hooks.systemAdd(self, systemInfo)
 
-	if type(system) == "table" and system.runCondition then
-		self:setRunCondition(systemFn, system.runCondition)
+	if type(system) == "table" and system.runConditions then
+		for _, condition in system.runConditions do
+			self:addRunCondition(systemFn, condition)
+		end
 	end
 
 	return self
@@ -662,7 +675,7 @@ function Scheduler:replaceSystem(old, new)
 	return self
 end
 
---- @method setRunCondition
+--- @method addRunCondition
 --- @within Scheduler
 --- @param system System
 --- @param fn (U...) -> boolean
@@ -670,25 +683,23 @@ end
 --- Adds a Run Condition which the Scheduler will check before
 --- this System is ran.
 
---- @method setRunCondition
+--- @method addRunCondition
 --- @within Scheduler
 --- @param phase Phase
 --- @param fn (U...) -> boolean
 ---
 --- Adds a Run Condition which the Scheduler will check before
---- any Systems tagged with this Phase are ran.
+--- any Systems within this Phase are ran.
 
---- @method setRunCondition
+--- @method addRunCondition
 --- @within Scheduler
 --- @param pipeline Pipeline
 --- @param fn (U...) -> boolean
 ---
 --- Adds a Run Condition which the Scheduler will check before
 --- any Systems within any Phases apart of this Pipeline are ran.\
---- \
---- This Run Condition will be applied to the Phases themselves.
 
-function Scheduler:setRunCondition(dependent, fn)
+function Scheduler:addRunCondition(dependent, fn)
 	local system = getSystem(dependent)
 	if system then
 		dependent = system
@@ -699,7 +710,12 @@ function Scheduler:setRunCondition(dependent, fn)
 		"Attempt to pass unknown dependent into Scheduler:setRunCondition(unknown, _)"
 	)
 
-	self._runIfConditions[dependent] = fn
+	if not self._runIfConditions[dependent] then
+		self._runIfConditions[dependent] = {}
+	end
+
+	table.insert(self._runIfConditions[dependent], fn)
+
 	return self
 end
 
@@ -713,7 +729,7 @@ function Scheduler:_addBuiltins()
 	local startupHasRan = {}
 
 	for _, phase in Pipeline.Startup.dependencyGraph.nodes do
-		self:setRunCondition(phase, function()
+		self:addRunCondition(phase, function()
 			local hasRan = startupHasRan[phase]
 
 			if not hasRan then

--- a/src/Scheduler.luau
+++ b/src/Scheduler.luau
@@ -5,6 +5,7 @@ local Phase = require("@Project/Phase")
 
 local utils = require("@Project/utils")
 local hooks = require("@Project/hooks")
+local conditions = require("@Project/conditions")
 
 local getSystem = utils.getSystem
 local getSystemName = utils.getSystemName
@@ -726,27 +727,19 @@ function Scheduler:_addBuiltins()
 	self._defaultDependencyGraph:insert(Pipeline.Startup)
 	self._defaultDependencyGraph:insert(self._defaultPhase)
 
-	local startupHasRan = {}
-
+	self:addRunCondition(Pipeline.Startup, conditions.runOnce())
 	for _, phase in Pipeline.Startup.dependencyGraph.nodes do
-		self:addRunCondition(phase, function()
-			local hasRan = startupHasRan[phase]
-
-			if not hasRan then
-				startupHasRan[phase] = true
-			end
-
-			return not hasRan
-		end)
+		self:addRunCondition(phase, conditions.runOnce())
 	end
 end
 
-local EVENT_CONNECT_METHODS = { "Connect", "On", "on", "connect" }
-
--- This is a modified function from Matter by evaera (https://github.com/evaera)
--- License: Copyright (c) 2021 Eryn L. K., MIT License
--- Source: https://github.com/matter-ecs/matter/blob/main/lib/hooks/useEvent.luau
 function Scheduler:_scheduleEvent(instance, event)
+	local connect = utils.getConnectFunction(instance, event)
+	assert(
+		connect,
+		"Couldn't connect to event as no valid connect methods were found! Ensure the passed event has a 'Connect' or an 'on' method!"
+	)
+
 	local identifier = getEventIdentifier(instance, event)
 
 	local dependencyGraph = DependencyGraph.new()
@@ -771,41 +764,9 @@ function Scheduler:_scheduleEvent(instance, event)
 		end
 	end
 
-	local eventInstance = instance
-
-	if typeof(event) == "RBXScriptSignal" or type(event) == "table" then
-		eventInstance = event
-	elseif type(event) == "string" then
-		eventInstance = instance[event]
-	end
-
-	if type(eventInstance) == "function" then
-		self._connectedEvents[identifier] = eventInstance
-		self._eventDependencyGraphs[identifier] = dependencyGraph
-
-		return eventInstance(eventInstance, callback)
-	elseif typeof(eventInstance) == "RBXScriptSignal" then
-		self._connectedEvents[identifier] = eventInstance
-		self._eventDependencyGraphs[identifier] = dependencyGraph
-
-		return eventInstance:Connect(callback)
-	end
-
-	if type(eventInstance) == "table" then
-		for _, method in EVENT_CONNECT_METHODS do
-			if type(eventInstance[method]) ~= "function" then
-				continue
-			end
-
-			self._connectedEvents[identifier] = eventInstance
-			self._eventDependencyGraphs[identifier] = dependencyGraph
-			return eventInstance[method](eventInstance, callback)
-		end
-	end
-
-	error(
-		"Couldn't connect to event as no valid connect methods were found! Ensure the passed event has a 'Connect' or an 'on' method!"
-	)
+	connect(callback)
+	self._connectedEvents[identifier] = true
+	self._eventDependencyGraphs[identifier] = dependencyGraph
 end
 
 function Scheduler:_getEventDependencyGraph(instance, event)

--- a/src/Scheduler.luau
+++ b/src/Scheduler.luau
@@ -1,5 +1,5 @@
-local RunService = game:GetService("RunService")
-
+--!nonstrict
+local DependencyGraph = require("@Project/DependencyGraph")
 local Pipeline = require("@Project/Pipeline")
 local Phase = require("@Project/Phase")
 
@@ -212,6 +212,10 @@ function Scheduler:runPhase(phase)
 
 	hooks.phaseBegan(self, phase)
 
+	if not self._phaseToSystems[phase] then
+		self._phaseToSystems[phase] = {}
+	end
+
 	for _, system in self._phaseToSystems[phase] do
 		self:runSystem(system)
 	end
@@ -223,7 +227,13 @@ function Scheduler:runPipeline(pipeline)
 		return
 	end
 
-	for _, phase in pipeline._phases do
+	local orderedList = pipeline.dependencyGraph:getOrderedList()
+	assert(
+		orderedList,
+		`Pipeline {pipeline} contains a circular dependency, check it's Phases`
+	)
+
+	for _, phase in orderedList do
 		self:runPhase(phase)
 	end
 end
@@ -274,37 +284,42 @@ end
 --- @return Scheduler
 ---
 --- Runs all Systems within order.
+---
+--- :::note
+--- When you add a Pipeline or Phase with an event, it will be grouped
+--- with other Pipelines/Phases on that event. Otherwise, it will be
+--- added to the default group.
+---
+--- When not running systems on Events, such as with the `runAll` method,
+--- the Default group will be ran first, and then each Event Group in the
+--- order created.
+---
+--- Pipelines/Phases in these groups are still ordered by their dependencies
+--- and by the order of insertion.
+--- :::
 function Scheduler:runAll()
-	for _, phase in self._orderedPhases do
-		self:run(phase)
-	end
-end
-
-function Scheduler:_insertPhaseAt(phase, index, instance, event)
+	local orderedDefaults = self._defaultDependencyGraph:getOrderedList()
 	assert(
-		not table.find(self._orderedPhases, phase),
-		"Phase already initialized"
+		orderedDefaults,
+		"Default Group contains a circular dependency, check your Pipelines/Phases"
 	)
 
-	table.insert(self._orderedPhases, index, phase)
-	self._phaseToSystems[phase] = {}
-
-	hooks.phaseAdd(self, phase)
-
-	if isValidEvent(instance, event) then
-		self:_schedulePhase(phase, instance, event)
+	for _, dependency in orderedDefaults do
+		self:run(dependency)
 	end
-end
 
-function Scheduler:insertPhase(phase, instance, event)
-	local index = table.find(self._orderedPhases, Phase.Update)
-	self:_insertPhaseAt(phase, index, instance, event)
-end
-
-function Scheduler:insertPipeline(pipeline, instance, event)
-	for _, phase in pipeline._phases do
-		self:insertPhase(phase, instance, event)
+	for identifier, dependencyGraph in self._eventDependencyGraphs do
+		local orderedList = dependencyGraph:getOrderedList()
+		assert(
+			orderedDefaults,
+			`Event Group '{identifier}' contains a circular dependency, check your Pipelines/Phases`
+		)
+		for _, dependency in orderedList do
+			self:run(dependency)
+		end
 	end
+
+	return self
 end
 
 --- @method insert
@@ -312,15 +327,17 @@ end
 --- @param phase Phase
 --- @return Scheduler
 ---
---- Initializes the Phase within the Scheduler, ordering it implicitly.
+--- Initializes the Phase within the Scheduler, ordering it implicitly by
+--- setting it as a dependent of the previous Phase/Pipeline.
 
 --- @method insert
 --- @within Scheduler
 --- @param pipeline Pipeline
 --- @return Scheduler
 ---
---- Initializes all Phases within the Pipeline within the Scheduler,
---- ordering the Pipeline implicitly.
+--- Initializes the Pipeline and it's Phases within the Scheduler,
+--- ordering the Pipeline implicitly by setting it as a dependent
+--- of the previous Phase/Pipeline.
 
 --- @method insert
 --- @within Scheduler
@@ -330,7 +347,8 @@ end
 --- @return Scheduler
 ---
 --- Initializes the Phase within the Scheduler, ordering it implicitly
---- and scheduling it to be ran on the specified event.
+--- by setting it as a dependent of the previous Phase/Pipeline, and
+--- scheduling it to be ran on the specified event.
 ---
 --- ```lua
 --- local myScheduler = Scheduler.new()
@@ -344,22 +362,38 @@ end
 --- @param event string | EventLike
 --- @return Scheduler
 ---
---- Initializes all Phases within the Pipeline within the Scheduler,
---- ordering the Pipeline implicitly and scheduling it to be ran on
---- the specified event.
+--- Initializes the Pipeline and it's Phases within the Scheduler,
+--- ordering the Pipeline implicitly by setting it as a dependent of
+--- the previous Phase/Pipeline, and scheduling it to be ran on the
+--- specified event.
 ---
 --- ```lua
 --- local myScheduler = Scheduler.new()
 ---     :insert(myPipeline, RunService, "Heartbeat")
 --- ```
 
-function Scheduler:insert(dependent, instance, event)
-	if isPhase(dependent) then
-		self:insertPhase(dependent, instance, event)
-	elseif isPipeline(dependent) then
-		self:insertPipeline(dependent, instance, event)
+function Scheduler:insert(dependency, instance, event)
+	assert(
+		isPhase(dependency) or isPipeline(dependency),
+		"Unknown dependency passed to Scheduler:insert(unknown, _, _)"
+	)
+
+	if not instance then
+		local dependencyGraph = self._defaultDependencyGraph
+		dependencyGraph:insertBefore(dependency, self._defaultPhase)
 	else
-		error("Unknown dependent passed to Scheduler:insert(unknown, _, _)")
+		assert(
+			isValidEvent(instance, event),
+			"Unknown instance/event passed to Scheduler:insert(_, instance, event)"
+		)
+
+		local dependencyGraph = self:_getEventDependencyGraph(instance, event)
+		dependencyGraph:insert(dependency)
+	end
+
+	if isPhase(dependency) then
+		self._phaseToSystems[dependency] = {}
+		hooks.phaseAdd(self, dependency)
 	end
 
 	return self
@@ -372,8 +406,7 @@ end
 --- @return Scheduler
 ---
 --- Initializes the Phase within the Scheduler, ordering it
---- explicitly after the Phase, or adding to the end of the
---- Pipeline provided.
+--- explicitly by setting the after Phase/Pipeline as a dependent.
 
 --- @method insertAfter
 --- @within Scheduler
@@ -381,40 +414,66 @@ end
 --- @param after Phase | Pipeline
 --- @return Scheduler
 ---
---- Initializes all Phases within the Pipeline within the Scheduler,
---- ordering the Pipeline explicitly after the Phase, or adding
---- to the end of the Pipeline provided.
+--- Initializes the Pipeline and it's Phases within the Scheduler,
+--- ordering the Pipeline explicitly by setting the after Phase/Pipeline
+--- as a dependent.
 
 function Scheduler:insertAfter(dependent, after)
-	if isPhase(after) then
-		local index = table.find(self._orderedPhases, after)
-		assert(
-			index,
-			"Phase never initialized in Scheduler:insertAfter(_, phase)"
-		)
+	assert(
+		isPhase(after) or isPipeline(after),
+		"Unknown dependency passed in Scheduler:insertAfter(_, unknown)"
+	)
+	assert(
+		isPhase(dependent) or isPipeline(dependent),
+		"Unknown dependent passed in Scheduler:insertAfter(unknown, _)"
+	)
 
-		if isPhase(dependent) then
-			self:_insertPhaseAt(dependent, index + 1)
-		elseif isPipeline(dependent) then
-			for _, phase in dependent._phases do
-				index += 1
-				self:_insertPhaseAt(phase, index)
-			end
-		else
-			error(
-				"Unknown dependent passed in Scheduler:insertAfter(unknown, _)"
-			)
-		end
-	elseif isPipeline(after) then
-		local before = after._phases[#after._phases]
+	local dependencyGraph = self:_getGraphOfDependency(after)
+	dependencyGraph:insertAfter(dependent, after)
 
-		if isPhase(dependent) then
-			after:insert(dependent)
-		end
+	if isPhase(dependent) then
+		self._phaseToSystems[dependent] = {}
+		hooks.phaseAdd(self, dependent)
+	end
 
-		self:insertAfter(dependent, before)
-	else
-		error("Unknown dependency passed in Scheduler:insertAfter(_, unknown)")
+	return self
+end
+
+--- @method insertBefore
+--- @within Scheduler
+--- @param phase Phase
+--- @param before Phase | Pipeline
+--- @return Scheduler
+---
+--- Initializes the Phase within the Scheduler, ordering it
+--- explicitly by setting the before Phase/Pipeline as a dependency.
+
+--- @method insertBefore
+--- @within Scheduler
+--- @param pipeline Pipeline
+--- @param before Phase | Pipeline
+--- @return Scheduler
+---
+--- Initializes the Pipeline and it's Phases within the Scheduler,
+--- ordering the Pipeline explicitly by setting the before Phase/Pipeline
+--- as a dependency.
+
+function Scheduler:insertBefore(dependent, before)
+	assert(
+		isPhase(before) or isPipeline(before),
+		"Unknown dependency passed in Scheduler:insertBefore(_, unknown)"
+	)
+	assert(
+		isPhase(dependent) or isPipeline(dependent),
+		"Unknown dependent passed in Scheduler:insertBefore(unknown, _)"
+	)
+
+	local dependencyGraph = self:_getGraphOfDependency(before)
+	dependencyGraph:insertBefore(dependent, before)
+
+	if isPhase(dependent) then
+		self._phaseToSystems[dependent] = {}
+		hooks.phaseAdd(self, dependent)
 	end
 
 	return self
@@ -450,11 +509,16 @@ function Scheduler:addSystem(system, phase)
 		if type(system) == "table" and system.phase then
 			systemInfo.phase = system.phase
 		else
-			systemInfo.phase = Phase.Update
+			systemInfo.phase = self._defaultPhase
 		end
 	end
 
 	self._systemInfo[systemFn] = systemInfo
+
+	if not self._phaseToSystems[systemInfo.phase] then
+		self._phaseToSystems[systemInfo.phase] = {}
+	end
+
 	table.insert(self._phaseToSystems[systemInfo.phase], systemFn)
 
 	hooks.systemAdd(self, systemInfo)
@@ -492,6 +556,8 @@ function Scheduler:addSystems(systems, phase)
 			"Unknown table passed to Scheduler:addSystems({ unknown }, phase?)"
 		)
 	end
+
+	return self
 end
 
 --- @method editSystem
@@ -519,6 +585,10 @@ function Scheduler:editSystem(system, newPhase)
 	assert(index, "Unable to find system within phase")
 
 	table.remove(systems, index)
+
+	if not self._phaseToSystems[newPhase] then
+		self._phaseToSystems[newPhase] = {}
+	end
 	table.insert(self._phaseToSystems[newPhase], systemFn)
 
 	systemInfo.phase = newPhase
@@ -634,33 +704,15 @@ function Scheduler:setRunCondition(dependent, fn)
 end
 
 function Scheduler:_addBuiltins()
-	local i = 0
+	self._defaultPhase = Phase.new("Default")
+	self._defaultDependencyGraph = DependencyGraph.new()
 
-	for _, phase in Pipeline.Startup._phases do
-		i += 1
-		self:_insertPhaseAt(phase, i)
-	end
-
-	for _, phase in Pipeline.Main._phases do
-		i += 1
-		self:_insertPhaseAt(phase, i, RunService, "Heartbeat")
-	end
-
-	local runServiceEvents = {
-		"PreRender",
-		"PreAnimation",
-		"PreSimulation",
-		"PostSimulation",
-	}
-
-	for _, event in runServiceEvents do
-		i += 1
-		self:_insertPhaseAt(Phase[event], i, RunService, event)
-	end
+	self._defaultDependencyGraph:insert(Pipeline.Startup)
+	self._defaultDependencyGraph:insert(self._defaultPhase)
 
 	local startupHasRan = {}
 
-	for _, phase in Pipeline.Startup._phases do
+	for _, phase in Pipeline.Startup.dependencyGraph.nodes do
 		self:setRunCondition(phase, function()
 			local hasRan = startupHasRan[phase]
 
@@ -681,9 +733,25 @@ local EVENT_CONNECT_METHODS = { "Connect", "On", "on", "connect" }
 function Scheduler:_scheduleEvent(instance, event)
 	local identifier = getEventIdentifier(instance, event)
 
+	local dependencyGraph = DependencyGraph.new()
+
 	local callback = function()
-		for _, phase in self._eventToPhases[identifier] do
-			self:run(phase)
+		local orderedList = dependencyGraph:getOrderedList()
+
+		if orderedList == nil then
+			local err =
+				`Event Group '{identifier}' contains a circular dependency, check your Pipelines/Phases`
+			if not recentLogs[err] then
+				task.spawn(error, err, 0)
+				warn(
+					`Planck: Error occurred while running event, this error will be ignored for 10 seconds`
+				)
+				recentLogs[err] = true
+			end
+		end
+
+		for _, dependency in orderedList do
+			self:run(dependency)
 		end
 	end
 
@@ -697,10 +765,12 @@ function Scheduler:_scheduleEvent(instance, event)
 
 	if type(eventInstance) == "function" then
 		self._connectedEvents[identifier] = eventInstance
+		self._eventDependencyGraphs[identifier] = dependencyGraph
 
 		return eventInstance(eventInstance, callback)
 	elseif typeof(eventInstance) == "RBXScriptSignal" then
 		self._connectedEvents[identifier] = eventInstance
+		self._eventDependencyGraphs[identifier] = dependencyGraph
 
 		return eventInstance:Connect(callback)
 	end
@@ -712,6 +782,7 @@ function Scheduler:_scheduleEvent(instance, event)
 			end
 
 			self._connectedEvents[identifier] = eventInstance
+			self._eventDependencyGraphs[identifier] = dependencyGraph
 			return eventInstance[method](eventInstance, callback)
 		end
 	end
@@ -721,17 +792,28 @@ function Scheduler:_scheduleEvent(instance, event)
 	)
 end
 
-function Scheduler:_schedulePhase(phase, instance, event)
+function Scheduler:_getEventDependencyGraph(instance, event)
 	local identifier = getEventIdentifier(instance, event)
 
-	if not self._eventToPhases[identifier] then
-		self._eventToPhases[identifier] = {}
-	end
-
-	table.insert(self._eventToPhases[identifier], phase)
 	if not self._connectedEvents[identifier] then
 		self:_scheduleEvent(instance, event)
 	end
+
+	return self._eventDependencyGraphs[identifier]
+end
+
+function Scheduler:_getGraphOfDependency(dependency)
+	if table.find(self._defaultDependencyGraph.nodes, dependency) then
+		return self._defaultDependencyGraph
+	end
+
+	for _, dependencyGraph in self._eventDependencyGraphs do
+		if table.find(dependencyGraph.nodes, dependency) then
+			return dependencyGraph
+		end
+	end
+
+	error("Dependency does not belong to a DependencyGraph")
 end
 
 --- @function new
@@ -747,10 +829,7 @@ function Scheduler.new(...)
 
 	self._vargs = { ... }
 
-	self._orderedPhases = {}
-	self._orderedPipelines = {}
-
-	self._eventToPhases = {}
+	self._eventDependencyGraphs = {}
 	self._connectedEvents = {}
 
 	self._phaseToSystems = {}

--- a/src/__tests__/Scheduler.test.luau
+++ b/src/__tests__/Scheduler.test.luau
@@ -19,11 +19,12 @@ describe("scheduler", function()
 			local myPhase = Phase.new("myPhase")
 			local myScheduler = Scheduler.new():insert(myPhase)
 
+			local orderedPhases =
+				myScheduler._defaultDependencyGraph:getOrderedList()
 			local mainIndex =
-				table.find(myScheduler._orderedPhases, Phase.Update)
+				table.find(orderedPhases, myScheduler._defaultPhase)
 
-			expect(myScheduler._orderedPhases[mainIndex - 1]).toBe(myPhase)
-			expect(myScheduler._phaseToSystems[myPhase]).toBeTruthy()
+			expect(orderedPhases[mainIndex - 1]).toBe(myPhase)
 		end)
 
 		test("phase with event", function()
@@ -32,18 +33,15 @@ describe("scheduler", function()
 			local myScheduler = Scheduler.new()
 				:insert(myPhase, RunService, "Heartbeat")
 
-			local mainIndex =
-				table.find(myScheduler._orderedPhases, Phase.Update)
-
-			expect(myScheduler._orderedPhases[mainIndex - 1]).toBe(myPhase)
-			expect(myScheduler._phaseToSystems[myPhase]).toBeTruthy()
-
 			local identifier = `{RunService}@Heartbeat`
-			local phases = myScheduler._eventToPhases[identifier]
+			local dependencyGraph =
+				myScheduler._eventDependencyGraphs[identifier]
 
-			expect(phases).toBeTruthy()
-			expect(phases).toContain(myPhase)
+			expect(dependencyGraph).toBeTruthy()
 			expect(myScheduler._connectedEvents[identifier]).toBeTruthy()
+
+			local orderedList = dependencyGraph:getOrderedList()
+			expect(orderedList[#orderedList]).toBe(myPhase)
 		end)
 
 		test("pipeline", function()
@@ -55,13 +53,16 @@ describe("scheduler", function()
 
 			local myScheduler = Scheduler.new():insert(myPipeline)
 
+			local orderedDependencies =
+				myScheduler._defaultDependencyGraph:getOrderedList()
 			local mainIndex =
-				table.find(myScheduler._orderedPhases, Phase.Update)
+				table.find(orderedDependencies, myScheduler._defaultPhase)
 
-			expect(myScheduler._orderedPhases[mainIndex - 2]).toBe(myPhase)
-			expect(myScheduler._orderedPhases[mainIndex - 1]).toBe(otherPhase)
-			expect(myScheduler._phaseToSystems[myPhase]).toBeTruthy()
-			expect(myScheduler._phaseToSystems[otherPhase]).toBeTruthy()
+			expect(orderedDependencies[mainIndex - 1]).toBe(myPipeline)
+
+			local orderedPhases = myPipeline.dependencyGraph:getOrderedList()
+			expect(orderedPhases[1]).toBe(myPhase)
+			expect(orderedPhases[2]).toBe(otherPhase)
 		end)
 
 		test("pipeline with event", function()
@@ -74,21 +75,19 @@ describe("scheduler", function()
 			local myScheduler = Scheduler.new()
 				:insert(myPipeline, RunService, "Heartbeat")
 
-			local mainIndex =
-				table.find(myScheduler._orderedPhases, Phase.Update)
-
-			expect(myScheduler._orderedPhases[mainIndex - 2]).toBe(myPhase)
-			expect(myScheduler._orderedPhases[mainIndex - 1]).toBe(otherPhase)
-			expect(myScheduler._phaseToSystems[myPhase]).toBeTruthy()
-			expect(myScheduler._phaseToSystems[otherPhase]).toBeTruthy()
-
 			local identifier = `{RunService}@Heartbeat`
-			local phases = myScheduler._eventToPhases[identifier]
+			local dependencyGraph =
+				myScheduler._eventDependencyGraphs[identifier]
 
-			expect(phases).toBeTruthy()
-			expect(phases).toContain(myPhase)
-			expect(phases).toContain(otherPhase)
+			expect(dependencyGraph).toBeTruthy()
 			expect(myScheduler._connectedEvents[identifier]).toBeTruthy()
+
+			local orderedList = dependencyGraph:getOrderedList()
+			expect(orderedList[1]).toBe(myPipeline)
+
+			local orderedPhases = myPipeline.dependencyGraph:getOrderedList()
+			expect(orderedPhases[1]).toBe(myPhase)
+			expect(orderedPhases[2]).toBe(otherPhase)
 		end)
 	end)
 
@@ -100,19 +99,17 @@ describe("scheduler", function()
 
 			local myScheduler = Scheduler.new()
 				:insert(phaseOne)
-				:insert(phaseThree)
-				:insertAfter(phaseTwo, phaseOne)
+				:insert(phaseTwo)
+				:insertAfter(phaseThree, phaseOne)
 
+			local orderedPhases =
+				myScheduler._defaultDependencyGraph:getOrderedList()
 			local mainIndex =
-				table.find(myScheduler._orderedPhases, Phase.Update)
+				table.find(orderedPhases, myScheduler._defaultPhase)
 
-			expect(myScheduler._orderedPhases[mainIndex - 3]).toBe(phaseOne)
-			expect(myScheduler._orderedPhases[mainIndex - 2]).toBe(phaseTwo)
-			expect(myScheduler._orderedPhases[mainIndex - 1]).toBe(phaseThree)
-
-			expect(myScheduler._phaseToSystems[phaseOne]).toBeTruthy()
-			expect(myScheduler._phaseToSystems[phaseTwo]).toBeTruthy()
-			expect(myScheduler._phaseToSystems[phaseThree]).toBeTruthy()
+			expect(orderedPhases[mainIndex - 3]).toBe(phaseOne)
+			expect(orderedPhases[mainIndex - 2]).toBe(phaseTwo)
+			expect(orderedPhases[mainIndex - 1]).toBe(phaseThree)
 		end)
 
 		test("pipeline", function()
@@ -130,17 +127,14 @@ describe("scheduler", function()
 				:insert(pipelineTwo)
 				:insertAfter(pipelineThree, pipelineOne)
 
+			local orderedDependencies =
+				myScheduler._defaultDependencyGraph:getOrderedList()
 			local mainIndex =
-				table.find(myScheduler._orderedPhases, Phase.Update)
-			expect(myScheduler._orderedPhases[mainIndex - 4]).toBe(phaseOne)
-			expect(myScheduler._orderedPhases[mainIndex - 3]).toBe(phaseTwo)
-			expect(myScheduler._orderedPhases[mainIndex - 2]).toBe(phaseThree)
-			expect(myScheduler._orderedPhases[mainIndex - 1]).toBe(phaseFour)
+				table.find(orderedDependencies, myScheduler._defaultPhase)
 
-			expect(myScheduler._phaseToSystems[phaseOne]).toBeTruthy()
-			expect(myScheduler._phaseToSystems[phaseTwo]).toBeTruthy()
-			expect(myScheduler._phaseToSystems[phaseThree]).toBeTruthy()
-			expect(myScheduler._phaseToSystems[phaseFour]).toBeTruthy()
+			expect(orderedDependencies[mainIndex - 3]).toBe(pipelineOne)
+			expect(orderedDependencies[mainIndex - 2]).toBe(pipelineTwo)
+			expect(orderedDependencies[mainIndex - 1]).toBe(pipelineThree)
 		end)
 	end)
 
@@ -237,13 +231,14 @@ describe("scheduler", function()
 			bindableEvent:Fire()
 		end)
 
-		test("each run exactly once", function()
+		test("each run exactly once", function(_, done)
 			expect.assertions(3)
 
 			local myPhase = Phase.new("myPhase")
 			local bindableEvent = Instance.new("BindableEvent")
 
 			local n = 0
+			local ranOnce = false
 
 			Scheduler.new()
 				:addSystem(function()
@@ -259,6 +254,13 @@ describe("scheduler", function()
 					expect(n).toEqual(3)
 				end, Phase.PostStartup)
 				:insert(myPhase, bindableEvent, bindableEvent.Event)
+				:addSystem(function()
+					if ranOnce then
+						done()
+					end
+
+					ranOnce = true
+				end, myPhase)
 
 			bindableEvent:Fire()
 			bindableEvent:Fire()

--- a/src/__tests__/Scheduler.test.luau
+++ b/src/__tests__/Scheduler.test.luau
@@ -151,7 +151,7 @@ describe("scheduler", function()
 		local myScheduler = Scheduler.new(1, 2, 3)
 			:insert(myPhase)
 			:addSystem(system, myPhase)
-			:setRunCondition(myPhase, function()
+			:addRunCondition(myPhase, function()
 				return bool
 			end)
 
@@ -177,7 +177,7 @@ describe("scheduler", function()
 		local myScheduler = Scheduler.new(1, 2, 3)
 			:insert(myPipeline)
 			:addSystem(system, myPhase)
-			:setRunCondition(myPipeline, function()
+			:addRunCondition(myPipeline, function()
 				return bool
 			end)
 

--- a/src/__tests__/conditions.test.luau
+++ b/src/__tests__/conditions.test.luau
@@ -1,0 +1,109 @@
+local JestGlobals = require("@DevPackages/JestGlobals")
+
+local Planck = require("@Project")
+local Scheduler = Planck.Scheduler
+
+local isNot = Planck.isNot
+local runOnce = Planck.runOnce
+local timePassed = Planck.timePassed
+local onEvent = Planck.onEvent
+
+local describe = JestGlobals.describe
+local expect = JestGlobals.expect
+local test = JestGlobals.test
+
+describe("conditions", function()
+	test("isNot", function()
+		expect.assertions(1)
+		local function system()
+			expect("Planckton!!!").toEqual(expect.anything())
+		end
+
+		local bool = false
+
+		local function condition()
+			return bool
+		end
+
+		local myScheduler = Scheduler.new()
+			:addSystem(system)
+			:addRunCondition(system, isNot(condition))
+
+		myScheduler:runAll() -- Expect to run
+
+		bool = true
+		myScheduler:runAll() -- Expect to not run
+	end)
+
+	test("runOnce", function()
+		expect.assertions(1)
+		local function system()
+			expect(true).toBe(true)
+		end
+
+		local myScheduler =
+			Scheduler.new():addSystem(system):addRunCondition(system, runOnce())
+
+		myScheduler:runAll() -- Expect to run
+		myScheduler:runAll() -- Expect to not run
+	end)
+
+	test("timePassed", function()
+		expect.assertions(3)
+		local didRun = false
+		local firstRun = false
+
+		local function system()
+			if firstRun then
+				didRun = true
+			end
+
+			firstRun = true
+		end
+
+		local myScheduler = Scheduler.new()
+			:addSystem(system)
+			:addRunCondition(system, timePassed(1))
+
+		myScheduler:runAll()
+		expect(didRun).toBe(false)
+		task.wait(0.5)
+
+		myScheduler:runAll()
+		expect(didRun).toBe(false)
+		task.wait(0.5)
+
+		myScheduler:runAll()
+		expect(didRun).toBe(true)
+	end)
+
+	test("onEvent", function()
+		expect.assertions(4)
+		local didRun = false
+		local bindableEvent = Instance.new("BindableEvent")
+
+		local function system()
+			didRun = true
+		end
+
+		local myScheduler = Scheduler.new():addSystem(system):addRunCondition(
+			system,
+			onEvent(bindableEvent, bindableEvent.Event)
+		)
+
+		myScheduler:runAll()
+		expect(didRun).toBe(false)
+		bindableEvent:Fire()
+
+		myScheduler:runAll()
+		expect(didRun).toBe(true)
+		didRun = false
+
+		myScheduler:runAll()
+		expect(didRun).toBe(false)
+		bindableEvent:Fire()
+
+		myScheduler:runAll()
+		expect(didRun).toBe(true)
+	end)
+end)

--- a/src/__tests__/systems.test.luau
+++ b/src/__tests__/systems.test.luau
@@ -117,7 +117,7 @@ describe("systems", function()
 		local myScheduler = Scheduler.new(1, 2, 3)
 			:insert(myPhase)
 			:addSystem(system, myPhase)
-			:setRunCondition(system, function()
+			:addRunCondition(system, function()
 				return bool
 			end)
 
@@ -125,6 +125,43 @@ describe("systems", function()
 
 		bool = false
 		myScheduler:runAll() -- Expect system to not run
+	end)
+
+	test("multiple run conditions", function()
+		expect.assertions(1)
+
+		local firstCondition = true
+		local secondCondition = true
+
+		local system = function(...)
+			expect({ ... }).toEqual({ 1, 2, 3 })
+		end
+
+		local myPhase = Phase.new("myPhase")
+		local myScheduler = Scheduler.new(1, 2, 3)
+			:insert(myPhase)
+			:addSystem(system, myPhase)
+			:addRunCondition(system, function()
+				return firstCondition
+			end)
+			:addRunCondition(system, function()
+				return secondCondition
+			end)
+
+		firstCondition = false
+		myScheduler:runAll()
+
+		firstCondition = true
+		secondCondition = false
+		myScheduler:runAll()
+
+		firstCondition = false
+		secondCondition = false
+		myScheduler:runAll()
+
+		firstCondition = true
+		secondCondition = true
+		myScheduler:runAll() -- Expect to run
 	end)
 
 	test("yield", function()

--- a/src/conditions.luau
+++ b/src/conditions.luau
@@ -1,0 +1,108 @@
+local utils = require("@Project/utils")
+local getConnectFunction = utils.getConnectFunction
+
+type EventLike = utils.EventLike
+type EventInstance = utils.EventInstance
+
+type Condition = () -> boolean
+
+--- @class Conditions
+
+--- @within Conditions
+--- @param time number -- Time in seconds
+--- @return hasTimePassed () -> boolean
+local function timePassed(time: number): Condition
+	local storedTime
+
+	return function()
+		if storedTime == nil or os.clock() - storedTime >= time then
+			storedTime = os.clock()
+			return true
+		end
+
+		return false
+	end
+end
+
+--- @within Conditions
+--- @return hasRanOnce () -> boolean
+local function runOnce(): Condition
+	local hasRan = false
+
+	return function()
+		if not hasRan then
+			hasRan = true
+			return true
+		end
+
+		return false
+	end
+end
+
+type CollectEvents<U...> = () -> () -> (number, U...)
+
+--- @within Conditions
+--- @return hasNewEvent () -> boolean
+--- @return collectEvents () -> () -> (number, U...)
+local function onEvent<U...>(
+	instance: EventInstance | EventLike,
+	event: string | EventLike
+): (Condition, CollectEvents<U...>)
+	local connect = getConnectFunction(instance, event)
+	assert(connect, "Event passed to .onEvent is not valid")
+
+	local newEvent = false
+	local queue = {}
+
+	local function callback(...)
+		newEvent = true
+		table.insert(queue, { ... })
+	end
+
+	connect(callback)
+
+	local function hasNewEvent()
+		if newEvent then
+			newEvent = false
+			return true
+		end
+
+		table.clear(queue)
+		return false
+	end
+
+	local function collectEvents()
+		local n = 0
+		return function(): (number, U...)
+			n += 1
+
+			local args = table.remove(queue, 1)
+
+			if args then
+				return n, table.unpack(args)
+			end
+
+			return nil :: any
+		end
+	end
+
+	return hasNewEvent, collectEvents
+end
+
+--- @within Conditions
+--- @param condition () -> boolean
+--- @return inverseCondition () -> boolean
+
+-- selene: allow(unused_variable)
+local function isNot(condition: Condition, ...: any): Condition
+	return function()
+		return not condition()
+	end
+end
+
+return {
+	timePassed = timePassed,
+	runOnce = runOnce,
+	onEvent = onEvent,
+	isNot = isNot,
+}

--- a/src/init.luau
+++ b/src/init.luau
@@ -2,6 +2,12 @@ local Phase = require("@Project/Phase") :: any
 local Pipeline = require("@Project/Pipeline") :: any
 local Scheduler = require("@Project/Scheduler") :: any
 
+local conditions = require("@Project/conditions")
+local utils = require("@Project/utils")
+
+type EventLike = utils.EventLike
+type EventInstance = utils.EventInstance
+
 export type SystemFn<U...> = ((U...) -> any) | ((U...) -> ())
 
 export type SystemTable<U...> = {
@@ -13,21 +19,6 @@ export type SystemTable<U...> = {
 }
 
 export type System<U...> = SystemFn<U...> | SystemTable<U...>
-
-type EventLike = RBXScriptSignal | {
-	connect: (self: EventLike, ...any) -> any,
-	[any]: any,
-} | {
-	Connect: (self: EventLike, ...any) -> any,
-	[any]: any,
-} | {
-	on: (self: EventLike, ...any) -> any,
-	[any]: any,
-}
-
-type EventInstance = Instance | {
-	[any]: EventLike,
-}
 
 export type Phase = {
 	PreStartup: Phase,
@@ -97,15 +88,18 @@ export type Scheduler<U...> = {
 	addRunCondition: ((
 		self: Scheduler<U...>,
 		system: System<U...>,
-		fn: (U...) -> boolean
+		fn: (U...) -> boolean,
+		...any
 	) -> Scheduler<U...>) & ((
 		self: Scheduler<U...>,
 		phase: Phase,
-		fn: (U...) -> boolean
+		fn: (U...) -> boolean,
+		...any
 	) -> Scheduler<U...>) & ((
 		self: Scheduler<U...>,
 		pipeline: Pipeline,
-		fn: (U...) -> boolean
+		fn: (U...) -> boolean,
+		...any
 	) -> Scheduler<U...>),
 
 	run: ((self: Scheduler<U...>, system: System<U...>) -> Scheduler<U...>)
@@ -150,4 +144,9 @@ return {
 	Scheduler = Scheduler :: {
 		new: <U...>(U...) -> Scheduler<U...>,
 	},
+
+	isNot = conditions.isNot,
+	runOnce = conditions.runOnce,
+	timePassed = conditions.timePassed,
+	onEvent = conditions.onEvent,
 }

--- a/src/init.luau
+++ b/src/init.luau
@@ -7,6 +7,8 @@ export type SystemFn<U...> = ((U...) -> any) | ((U...) -> ())
 export type SystemTable<U...> = {
 	system: SystemFn<U...>,
 	phase: Phase?,
+	name: string?,
+	runConditions: { (U...) -> boolean }?,
 	[any]: any,
 }
 
@@ -92,7 +94,7 @@ export type Scheduler<U...> = {
 		system: System<U...>
 	) -> Scheduler<U...>,
 
-	setRunCondition: ((
+	addRunCondition: ((
 		self: Scheduler<U...>,
 		system: System<U...>,
 		fn: (U...) -> boolean

--- a/src/utils.luau
+++ b/src/utils.luau
@@ -53,19 +53,44 @@ end
 
 local EVENT_CONNECT_METHODS = { "Connect", "On", "on", "connect" }
 
-local function isValidEvent(instance, event)
+export type EventLike = RBXScriptSignal | {
+	connect: (self: EventLike, ...any) -> any,
+	[any]: any,
+} | {
+	Connect: (self: EventLike, ...any) -> any,
+	[any]: any,
+} | {
+	on: (self: EventLike, ...any) -> any,
+	[any]: any,
+}
+
+export type EventInstance = Instance | {
+	[any]: EventLike,
+}
+
+type ConnectFn<U...> = (callback: (U...) -> ()) -> ()
+
+-- This function is inspired by useEvent in Matter, a library by evaera (https://github.com/evaera)
+-- License: Copyright (c) 2021 Eryn L. K., MIT License
+-- Source: https://github.com/matter-ecs/matter/blob/main/lib/hooks/useEvent.luau
+local function getConnectFunction<U...>(
+	instance: EventInstance | EventLike,
+	event: string | EventLike
+): ConnectFn<U...>?
 	local eventInstance = instance
 
 	if typeof(event) == "RBXScriptSignal" or type(event) == "table" then
 		eventInstance = event
 	elseif type(event) == "string" then
-		eventInstance = instance[event]
+		eventInstance = (instance :: any)[event]
 	end
 
 	if type(eventInstance) == "function" then
-		return true
+		return eventInstance
 	elseif typeof(eventInstance) == "RBXScriptSignal" then
-		return true
+		return function(callback)
+			eventInstance:Connect(callback)
+		end
 	end
 
 	if type(eventInstance) == "table" then
@@ -74,11 +99,17 @@ local function isValidEvent(instance, event)
 				continue
 			end
 
-			return true
+			return function(callback)
+				eventInstance[method](eventInstance, callback)
+			end
 		end
 	end
 
-	return false
+	return nil
+end
+
+local function isValidEvent(instance, event)
+	return getConnectFunction(instance, event) ~= nil
 end
 
 return {
@@ -88,4 +119,5 @@ return {
 	isPipeline = isPipeline,
 	getEventIdentifier = getEventIdentifier,
 	isValidEvent = isValidEvent,
+	getConnectFunction = getConnectFunction,
 }

--- a/src/utils.luau
+++ b/src/utils.luau
@@ -24,7 +24,8 @@ end
 local function getSystemName(system: any): string
 	local name = debug.info(system, "n")
 	if not name or string.len(name) == 0 then
-		name = debug.info(system, "sl")
+		local source, line = debug.info(system, "sl")
+		name = `{source}:{line}`
 	end
 
 	return name


### PR DESCRIPTION
# Changes

## Added

- `Scheduler:insertBefore()`
- `Pipeline:insertBefore()`
- Conditions (isNot, runOnce, timePassed, onEvent)
- `Scheduler:addRunCondition()` for adding multiple run conditions

## Changed

- Refactored internals to use Adjacency Matrices for managing ordering and dependencies of Phases/Pipelines
- **Breaking:** The following methods now create an ordering dependency instead of setting the fixed order of Phases/Pipelines
  - `Scheduler:insert()`
  - `Scheduler:insertAfter()`
  - `Pipeline:insert()`
  - `Pipeline:insertAfter()`
- **Breaking:** `Scheduler:runAll()` will no longer run in the exact order that Phases were inserted for Phases bound to events. They will be grouped together, and ran together in order of insertion.
- **Breaking:** `Scheduler:setRunCondition()` has been replaced with `Scheduler:addRunCondition()`
- **Breaking:** `SystemTable.runCondition` has been replaced with `SystemTable.runConditions`
- Refactored internals to reuse event logic
- Replaced `Phase.Update` as default phase with `Default`
  
## Removed

- Built-in RunService Pipelines/Phases, these will be available as a separate plugin

## Fixed

- Fallback System name does not contain the line of the system

# To-do

- [ ] Create a `planck_runservice_phases` plugin
- [ ] Update Documentation