### PR TITLE
#16 Fix: Conflict Between Planck Matter Hooks and Matter Hooks Libraries

### DIFF
--- a/plugins/planck_matter_hooks/src/init.lua
+++ b/plugins/planck_matter_hooks/src/init.lua
@@ -69,8 +69,8 @@ end
 if ReplicatedStorage:FindFirstChild("Packages") then
 	for _, package in ReplicatedStorage.Packages._Index:GetChildren() do
 		if
-			string.find(package.Name, "matter%-ecs_matter")
-			or string.find(package.Name, "evaera_matter")
+			string.find(package.Name, "matter%-ecs_matter@")
+			or string.find(package.Name, "evaera_matter@")
 		then
 			setHooks(package)
 			break


### PR DESCRIPTION
Resolves #16.

Mirrored this change in my local install of Planck in a game project, then observed the issue no longer occurring at runtime.