### PR TITLE
Update Plugin type in plugins

### DIFF
--- a/plugins/planck_jabby/src/init.luau
+++ b/plugins/planck_jabby/src/init.luau
@@ -133,6 +133,7 @@ type SchedulerLike<U...> = {
 
 type Plugin<U...> = {
 	build: (self: Plugin<U...>, scheduler: SchedulerLike<U...>) -> (),
+	cleanup: ((self: Plugin<U...>) -> ())?,
 	new: () -> Plugin<U...>,
 }
 

--- a/plugins/planck_matter_debugger/src/init.lua
+++ b/plugins/planck_matter_debugger/src/init.lua
@@ -256,6 +256,7 @@ type Plugin<U...> = {
 		[any]: any,
 	},
 	build: (self: Plugin<U...>, scheduler: SchedulerLike<U...>) -> (),
+	cleanup: ((self: Plugin<U...>) -> ())?,
 	new: () -> Plugin<U...>,
 }
 

--- a/plugins/planck_matter_hooks/src/init.lua
+++ b/plugins/planck_matter_hooks/src/init.lua
@@ -248,6 +248,7 @@ type Plugin<U...> = {
 		[any]: any,
 	},
 	build: (self: Plugin<U...>, scheduler: SchedulerLike<U...>) -> (),
+	cleanup: ((self: Plugin<U...>) -> ())?,
 	new: (module: ModuleScript?) -> Plugin<U...>,
 }
 

--- a/plugins/planck_runservice/src/init.luau
+++ b/plugins/planck_runservice/src/init.luau
@@ -107,6 +107,7 @@ end
 
 type Plugin<U...> = {
 	build: (self: Plugin<U...>, scheduler: Scheduler<U...>) -> (),
+	cleanup: ((self: Plugin<U...>) -> ())?,
 	new: () -> Plugin<U...>,
 }
 


### PR DESCRIPTION
The Scheduler expects a Plugin type with a cleanup field, which the default plugins currently don't have, as they have their own Plugin type.