### PR TITLE
Add initializer systems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2449,7 +2449,7 @@
 		},
 		"out/planck": {
 			"name": "@rbxts/planck",
-			"version": "0.2.0-rc.1",
+			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@rbxts/compiler-types": "^2.3.0-types.1",
@@ -2467,7 +2467,7 @@
 		},
 		"out/planck_jabby": {
 			"name": "@rbxts/planck-jabby",
-			"version": "0.2.0-rc.1",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@rbxts/jabby": "^0.2.0-rc.8",
@@ -2489,7 +2489,7 @@
 		},
 		"out/planck_matter_debugger": {
 			"name": "@rbxts/planck-matter-debugger",
-			"version": "0.2.0-rc.1",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@rbxts/planck": "^0.2.0-rc.1"
@@ -2510,7 +2510,7 @@
 		},
 		"out/planck_matter_hooks": {
 			"name": "@rbxts/planck-matter-hooks",
-			"version": "0.2.0-rc.1",
+			"version": "0.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"@rbxts/planck": "^0.2.0-rc.1"
@@ -2531,7 +2531,7 @@
 		},
 		"out/planck_runservice": {
 			"name": "@rbxts/planck-runservice",
-			"version": "0.2.0-rc.1",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@rbxts/planck": "^0.2.0-rc.1"

--- a/src/planck/src/Scheduler.luau
+++ b/src/planck/src/Scheduler.luau
@@ -131,20 +131,21 @@ function Scheduler:runSystem(system)
 	end
 
 	local didYield = false
+	local errOrSys
 
 	local function systemCall()
 		local function noYield()
-			local success, err
+			local success
 			coroutine.resume(self._thread, function()
-				success, err = xpcall(system, function(e)
+				success, errOrSys = xpcall(system, function(e)
 					return debug.traceback(e)
 				end, table.unpack(self._vargs))
 			end)
 
 			if success == false then
 				didYield = true
-				table.insert(systemInfo.logs, err)
-				hooks.systemError(self, systemInfo, err)
+				table.insert(systemInfo.logs, errOrSys)
+				hooks.systemError(self, systemInfo, errOrSys)
 				return
 			end
 
@@ -210,6 +211,7 @@ function Scheduler:runSystem(system)
 	end
 
 	self:_handleLogs(systemInfo)
+	return errOrSys
 end
 
 function Scheduler:runPhase(phase)
@@ -242,6 +244,63 @@ function Scheduler:runPipeline(pipeline)
 	for _, phase in orderedList do
 		self:runPhase(phase)
 	end
+end
+
+function Scheduler:runStartup()
+	if self:_canRun(Pipeline.Startup) == false then
+		return
+	end
+
+	local orderedList = Pipeline.Startup.dependencyGraph:getOrderedList()
+	assert(
+		orderedList,
+		`Pipeline {Pipeline.Startup} contains a circular dependency, check it's Phases`
+	)
+
+	for _, phase in orderedList do
+		if self:_canRun(phase) == false then
+			continue
+		end
+
+		hooks.phaseBegan(self, phase)
+
+		if not self._phaseToSystems[phase] then
+			self._phaseToSystems[phase] = {}
+		end
+
+		for _, system in self._phaseToSystems[phase] do
+			local systemInfo = self._systemInfo[system]
+			if systemInfo.initializer then
+				self:_resolveSystemInitializer(system, systemInfo)
+			else
+				self:runSystem(system)
+			end
+		end
+	end
+end
+
+function Scheduler:_resolveSystemInitializer(system, systemInfo)
+	-- System initializers are functions that return the actual runtime system
+	-- function, allowing initialization logic to run once during startup while
+	-- the returned function becomes the system that runs each frame. During
+	-- resolution, this creates two distinct systems: the original function
+	-- becomes an initialization system that executes once, and the returned
+	-- function becomes the runtime system that executes repeatedly.
+	local result = self:runSystem(system)
+
+	if type(result) ~= "function" then
+		local err = `System '{systemInfo.name}' did not return a function`
+		table.insert(systemInfo.logs, err)
+		hooks.systemError(self, systemInfo, err)
+		return
+	end
+
+	local inner = table.clone(systemInfo)
+	inner.initializer = nil
+	inner.system = result
+	inner.phase = systemInfo.innerPhase
+
+	self:addSystem(inner, systemInfo.innerPhase)
 end
 
 function Scheduler:_canRun(dependent)
@@ -284,7 +343,7 @@ function Scheduler:run(dependent)
 		error("No dependent specified in Scheduler:run(_)")
 	end
 
-	self:runPipeline(Pipeline.Startup)
+	self:runStartup()
 
 	if getSystem(dependent) then
 		self:runSystem(dependent)
@@ -518,20 +577,30 @@ function Scheduler:addSystem(system, phase)
 		name = system.name
 	end
 
+	local initializer = if type(system) == "table"
+		then system.initializer
+		else nil
+
+	local scheduledPhase = (function()
+		if phase then
+			return phase
+		end
+
+		if type(system) == "table" and system.phase then
+			return system.phase
+		end
+
+		return self._defaultPhase
+	end)()
+
 	local systemInfo = {
 		system = systemFn,
-		phase = phase,
+		phase = if initializer then initializer else scheduledPhase,
+		innerPhase = scheduledPhase,
 		name = name,
 		logs = {},
+		initializer = initializer,
 	}
-
-	if not phase then
-		if type(system) == "table" and system.phase then
-			systemInfo.phase = system.phase
-		else
-			systemInfo.phase = self._defaultPhase
-		end
-	end
 
 	self._systemInfo[systemFn] = systemInfo
 
@@ -599,7 +668,7 @@ function Scheduler:editSystem(system, newPhase)
 	local systemInfo = self._systemInfo[systemFn]
 	assert(
 		systemInfo,
-		"Attempt to remove a non-exist system in Scheduler:removeSystem(_)"
+		"Attempt to edit a non-existent system in Scheduler:editSystem(_)"
 	)
 
 	assert(

--- a/src/planck/src/init.luau
+++ b/src/planck/src/init.luau
@@ -11,13 +11,17 @@ type ConnectionLike = utils.ConnectionLike
 type ConnectFn<T, U...> = utils.ConnectFn<T, U...>
 type Callback<U...> = utils.Callback<U...>
 
-export type SystemFn<U...> = ((U...) -> any) | ((U...) -> ())
+export type SystemFn<U...> =
+	| ((U...) -> any)
+	| ((U...) -> ())
+	| (U...) -> SystemFn<U...>
 
 export type SystemTable<U...> = {
 	system: SystemFn<U...>,
 	phase: Phase?,
 	name: string?,
 	runConditions: { (U...) -> boolean }?,
+	initializer: Phase?,
 	[any]: any,
 }
 
@@ -39,14 +43,16 @@ export type Pipeline = {
 	new: (debugName: string?) -> Pipeline,
 }
 
-type Plugin<U...> = {
-	build: (self: Plugin<U...>, scheduler: Scheduler<U...>) -> (),
-	[any]: any,
-} | {
-	build: (self: Plugin<U...>, scheduler: Scheduler<U...>) -> (),
-	cleanup: (self: Plugin<U...>) -> (),
-	[any]: any,
-}
+type Plugin<U...> =
+	{
+		build: (self: Plugin<U...>, scheduler: Scheduler<U...>) -> (),
+		[any]: any,
+	}
+	| {
+		build: (self: Plugin<U...>, scheduler: Scheduler<U...>) -> (),
+		cleanup: (self: Plugin<U...>) -> (),
+		[any]: any,
+	}
 
 export type Scheduler<U...> = {
 	addPlugin: (self: Scheduler<U...>, plugin: Plugin<U...>) -> Scheduler<U...>,

--- a/src/planck/src/utils.luau
+++ b/src/planck/src/utils.luau
@@ -2,14 +2,15 @@ type Phase = any
 type Pipeline = any
 
 type SystemFn<U...> = ((U...) -> any) | ((U...) -> ())
+type SystemInitializerFn<U...> = (U...) -> SystemFn<U...>
 
 type SystemTable<U...> = {
-	system: SystemFn<U...>,
+	system: SystemFn<U...> | SystemInitializerFn<U...>,
 	phase: Phase?,
 	[any]: any,
 }
 
-type System<U...> = SystemFn<U...> | SystemTable<U...>
+type System<U...> = SystemFn<U...> | SystemInitializerFn<U...> | SystemTable<U...>
 
 local function getSystem<U...>(system: any): SystemTable<U...>?
 	if type(system) == "function" then
@@ -94,19 +95,23 @@ export type Callback<U...> = (U...) -> ...any
 export type ConnectFn<T, U...> = (callback: (U...) -> ...any) -> T
 export type GenericTable = { [any]: any }
 
-export type SignalLike<U...> = {
-	connect: (self: SignalLike<U...>, Callback<U...>, ...any?) -> any,
-	[any]: any,
-} | {
-	Connect: (self: SignalLike<U...>, Callback<U...>, ...any?) -> any,
-	[any]: any,
-} | {
-	on: (self: SignalLike<U...>, Callback<U...>, ...any?) -> any,
-	[any]: any,
-} | {
-	On: (self: SignalLike<U...>, Callback<U...>, ...any?) -> any,
-	[any]: any,
-}
+export type SignalLike<U...> =
+	{
+		connect: (self: SignalLike<U...>, Callback<U...>, ...any?) -> any,
+		[any]: any,
+	}
+	| {
+		Connect: (self: SignalLike<U...>, Callback<U...>, ...any?) -> any,
+		[any]: any,
+	}
+	| {
+		on: (self: SignalLike<U...>, Callback<U...>, ...any?) -> any,
+		[any]: any,
+	}
+	| {
+		On: (self: SignalLike<U...>, Callback<U...>, ...any?) -> any,
+		[any]: any,
+	}
 
 type GetConnectFn<U...> =
 	-- RBXScriptSignal & nil

--- a/wally.lock
+++ b/wally.lock
@@ -264,5 +264,5 @@ dependencies = []
 
 [[package]]
 name = "yetanotherclown/planck"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [["Jabby", "alicesaidhi/jabby@0.2.3"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"]]


### PR DESCRIPTION
Adds the concept of "system initializers" that allows a system to run once for setup, without relying on a separate system.

```luau
-- System initializer: runs once during startup, returns runtime system
local function example(world)
    -- runs once on the initializer phase

    -- Return the actual system that runs each frame
    return function()
        -- runs
    end
end

scheduler:addSystem({
    system = example,
    initializer = Phase.PreStartup,  -- When to run initialization
    phase = Phase.Update             -- When to run the returned system
})
```

This internally works by treating the two systems as different systems. We use the `initializer` flag to run the first system as a startup phase under jabby, then when this runs, we create a 2nd system from the return function, using the same state as the first minus the initialzer, so that it runs with its normal phase.

The caveat is that this doesn't work with hot-reloading, but I cannot figure out a way to do this as to get the inner system we will always need to run the first part.

This is currently a draft as I'm missing tests (all existing tests still pass), but I kept reworking my implementation that I decided to get this out as a draft for review first. I wanted to avoid the overhead of checking for these systems in `runSystem` so that we didn't get the overhead of this check when they're only designed as startup systems, which is why the old `runPipeline(Pipeline.Startup)` has been changed. Due to this, a system that is scheduled after the startup would never run once, and a system can only currently be apart of `Startup`, `PreStartup`, or `PostStartup`, which may potentially not be ideal. I had originally planned for the start system to just run before the inner system on its phase (e.g. `Phases.PostUpdate`), but reverted this due to Jabby's concept of a startup system.

I think this could be improved, but it depends what the best way to go is. For example, maybe it would be okay to re-run startup systems in some cases, if we had the ability to "know" it'd been hot-reloaded and then recompute changes accordingly, but maybe this is for a future issue.

