### PR TITLE
Fixed planck jabby, now references correct path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ node_modules/
 out/
 package_tarballs/
 builds/
+.devenv
+
+# Nix / direnv artifacts
+.envrc
+flake.nix
+flake.lock
+.direnv/
+.direnv/**

--- a/src/planck_jabby/src/init.luau
+++ b/src/planck_jabby/src/init.luau
@@ -1,4 +1,20 @@
-local Jabby = require(script.Parent.Jabby)
+local Jabby = (function()
+	-- Try to use the TS runtime import if present on _G for npm-packaged code.
+	local ok, TS = pcall(function() return _G[script] end)
+	if ok and TS ~= nil then
+		return (TS.import(script, TS.getModule(script, "@rbxts", "jabby").out) :: any)
+	end
+
+	-- Fallback to local module require for tests / local usage
+	local mod = (script.Parent :: Instance):FindFirstChild("Jabby")
+	if mod then
+		return (require(mod :: any) :: any)
+	end
+
+	-- No module found; return nil. In practice the TS import path will be used when
+	-- publishing to npm, so this branch is only for edge cases/tests.
+	return nil
+end)()
 
 type SystemInfo = {
 	name: string,


### PR DESCRIPTION
This pull request updates the way the `Jabby` module is imported in `init.luau` to better support both npm-packaged and local/test environments. The code now first attempts to use a TypeScript runtime import if available, and falls back to the previous local module loading approach if not.

Module import improvements:

* Updated the `Jabby` import logic in `init.luau` to first check for a TypeScript runtime import via `_G`, supporting npm-packaged usage, and fall back to local `require` for tests or local development. This makes the module more robust and compatible with different environments.