### PR TITLE
Document multiple run conditions better, and check for falsy values instead

### DIFF
--- a/docs/design/conditions.md
+++ b/docs/design/conditions.md
@@ -19,9 +19,8 @@ Run Conditions are very simple, they are just functions that return true or
 false.
 
 :::note
-One system may have multiple Run Conditions. If at least one Run Condition
-returns `false`, the system's execution will be skipped. Void or `nil`
-values get interpreted as truthy and will not prevent the system from running.
+One System/Phase/Pipeline may have multiple Run Conditions. If at least one Run Condition
+returns a falsy value (`nil`, `void`, `false`), its execution will be skipped.
 :::
 
 We can set a Run Condition on a System/Phase/Pipeline like so,

--- a/docs/design/conditions.md
+++ b/docs/design/conditions.md
@@ -18,6 +18,10 @@ In Planck, we can assign *Run Conditions* to Systems, Phases, and Pipelines.
 Run Conditions are very simple, they are just functions that return true or
 false.
 
+One system may have multiple Run Conditions. If at least one Run Condition
+returns `false`, the system's execution will be skipped. Void or `nil`
+values get interpreted as truthy and will not prevent the system from running.
+
 We can set a Run Condition on a System/Phase/Pipeline like so,
 
 <Tabs groupId="language">

--- a/docs/design/conditions.md
+++ b/docs/design/conditions.md
@@ -18,9 +18,11 @@ In Planck, we can assign *Run Conditions* to Systems, Phases, and Pipelines.
 Run Conditions are very simple, they are just functions that return true or
 false.
 
+:::note
 One system may have multiple Run Conditions. If at least one Run Condition
 returns `false`, the system's execution will be skipped. Void or `nil`
 values get interpreted as truthy and will not prevent the system from running.
+:::
 
 We can set a Run Condition on a System/Phase/Pipeline like so,
 

--- a/src/planck/src/Scheduler.luau
+++ b/src/planck/src/Scheduler.luau
@@ -332,7 +332,7 @@ function Scheduler:_canRun(dependent)
 
 	if conditions then
 		for _, runIf in conditions do
-			if runIf(table.unpack(self._vargs)) == false then
+			if runIf and not runIf(table.unpack(self._vargs)) then
 				return false
 			end
 		end
@@ -876,7 +876,7 @@ end
 --- @method addRunCondition
 --- @within Scheduler
 --- @param system System
---- @param fn (U...) -> boolean
+--- @param fn (U...) -> any
 ---
 --- Adds a Run Condition which the Scheduler will check before
 --- this System is ran.
@@ -884,7 +884,7 @@ end
 --- @method addRunCondition
 --- @within Scheduler
 --- @param phase Phase
---- @param fn (U...) -> boolean
+--- @param fn (U...) -> any
 ---
 --- Adds a Run Condition which the Scheduler will check before
 --- any Systems within this Phase are ran.
@@ -892,7 +892,7 @@ end
 --- @method addRunCondition
 --- @within Scheduler
 --- @param pipeline Pipeline
---- @param fn (U...) -> boolean
+--- @param fn (U...) -> any
 ---
 --- Adds a Run Condition which the Scheduler will check before
 --- any Systems within any Phases apart of this Pipeline are ran.

--- a/src/planck/src/conditions.d.ts
+++ b/src/planck/src/conditions.d.ts
@@ -1,8 +1,11 @@
 import type { EventInstance, EventLike, ExtractEvents } from "./utils";
 
+/**
+ * If a Run Condition returns a falsy value (`nil`, `void`, `false`), the System/Phase/Pipeline will be prevented from running.
+ */
 export type Condition<T extends unknown[] = unknown[]> = (
   ...args: T
-) => boolean;
+) => unknown | void;
 
 /**
  * A Throttle condition which checks whether the amount of time given has passed

--- a/src/planck/src/init.luau
+++ b/src/planck/src/init.luau
@@ -29,7 +29,7 @@ export type SystemTable<U...> = {
 	system: SystemFn<U...> | InitializerSystemFn<U...>,
 	phase: Phase?,
 	name: string?,
-	runConditions: { (U...) -> boolean }?,
+	runConditions: { Condition<U...> }?,
 	[any]: any,
 }
 
@@ -66,6 +66,8 @@ type Plugin<U...> =
 		[any]: any,
 	}
 
+export type Condition<U...> = (U...) -> any
+
 export type Scheduler<U...> = {
 	addPlugin: (self: Scheduler<U...>, plugin: Plugin<U...>) -> Scheduler<U...>,
 
@@ -101,17 +103,17 @@ export type Scheduler<U...> = {
 	addRunCondition: ((
 		self: Scheduler<U...>,
 		system: System<U...>,
-		fn: (U...) -> boolean,
+		fn: Condition<U...>,
 		...any
 	) -> Scheduler<U...>) & ((
 		self: Scheduler<U...>,
 		phase: Phase,
-		fn: (U...) -> boolean,
+		fn: Condition<U...>,
 		...any
 	) -> Scheduler<U...>) & ((
 		self: Scheduler<U...>,
 		pipeline: Pipeline,
-		fn: (U...) -> boolean,
+		fn: Condition<U...>,
 		...any
 	) -> Scheduler<U...>),
 


### PR DESCRIPTION
Documents that multiple Run Conditions may exist, and that if at least one of them is `false`, execution is skipped.